### PR TITLE
Fixing out of bounds error in Viewer4d

### DIFF
--- a/pynax/Viewer4D.py
+++ b/pynax/Viewer4D.py
@@ -37,7 +37,7 @@ def show(*args):
             fig.propagate_changes([mn])
 
     slider_ax = fig.get_subplot((1, 0), (3, 1))
-    slider = widgets.Slider(slider_ax, 'n', 0, layers[0][0].shape[-1])
+    slider = widgets.Slider(slider_ax, 'n', 0, layers[0][0].shape[-1] - 1)
     slider.on_changed(update)
     """
     for data, options in layers[1:]:


### PR DESCRIPTION
This happes when the slider widget in Viewer4D moves to the very right.

Slider widget considers valmax as a closed interval boundary by default. 
Possible to also use closedmax=False instead but this could cause same issue when rounding the index instead of flooring.
